### PR TITLE
Implement connection close

### DIFF
--- a/dbt/adapters/singlestore/connections.py
+++ b/dbt/adapters/singlestore/connections.py
@@ -96,7 +96,11 @@ class SingleStoreConnectionManager(SQLConnectionManager):
         )
 
     def cancel(self, connection):
-        pass
+       connection_name = connection.name
+       query_id = connection.handle.thread_id()
+       kill_sql = f"kill query {query_id}"
+       logger.debug("Cancelling query {} of connection '{}'".format(id, connection_name))
+       self.execute(kill_sql)
 
     @contextmanager
     def exception_handler(self, sql):

--- a/dbt/adapters/singlestore/impl.py
+++ b/dbt/adapters/singlestore/impl.py
@@ -64,7 +64,7 @@ class SingleStoreAdapter(SQLAdapter):
 
     @classmethod
     def is_cancelable(cls):
-        return False
+        return True
 
     def quote(self, identifier):
         return '`{}`'.format(identifier)


### PR DESCRIPTION
Kill running queries when cancelling job to not waist resources on singlestore cluster.

If we have the incremental job running periodically, and one of the queries takes too long to execute, we want to kill it when the dbt job times-out (by cancelling job). If this is not implemented and query is not killed, we can have multiple long running queries continuously added to cluster for execution on every incremental job run.

