### PR TITLE
Check for shard key or sort key before creating the temporary command

### DIFF
--- a/dbt/include/singlestore/macros/common.sql
+++ b/dbt/include/singlestore/macros/common.sql
@@ -108,7 +108,11 @@
     {{ sql_header if sql_header is not none }}
 
     {% if temporary -%}
-        {% set storage_type = 'rowstore temporary' -%}
+        {% if shard_key | length or sort_key | length -%}
+            {% set storage_type = 'temporary' -%}
+        {% else -%}
+            {% set storage_type = 'rowstore temporary' -%}
+        {% endif -%}
     {% elif config.get('storage_type') == 'rowstore' -%}
         {% set storage_type = 'rowstore' -%}
     {% else -%}


### PR DESCRIPTION
**Summary**: 
This PR addresses a compatibility issue in Singlestore for incremental models using `shard_key` or `sort_key`. Previously, attempting to use these keys would fail due to an incorrect assumption that temporary tables are rowstore, which is not supported by Singlestore for `CLUSTERED COLUMNAR` indexes.

**Details**:
- **Problem**: Models with `shard_key` or `sort_key` couldn't be deployed as incremental tables because the system tried to create them as rowstore temporary tables, conflicting with Singlestore's requirements.
- **Solution**: We've updated the logic to dynamically set the storage type for temporary tables. If a model has `shard_key` or `sort_key`, it's created as a "temporary" table (compatible with these keys), otherwise, it defaults to "rowstore temporary".
- **Benefits**: This update ensures that all incremental models, regardless of their key configurations, can be deployed successfully in Singlestore.