### PR TITLE
Fixed version number info used for SingleStore adapter

### DIFF
--- a/dbt/adapters/singlestore/__version__.py
+++ b/dbt/adapters/singlestore/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.0"
+version = "1.8.1"

--- a/dbt/adapters/singlestore/__version__.py
+++ b/dbt/adapters/singlestore/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.1"
+version = "1.8.0"


### PR DESCRIPTION
Simple fix for output of 'dbt --version' command reporting adapter version 1.7.1 after fresh install of dbt-singlestore using pip.

Current output:
```bash
Core:
  - installed: 1.9.3
  - latest:    1.9.3 - Up to date!

Plugins:
  - singlestore: 1.7.1 - Update available!

  At least one plugin is out of date with dbt-core.
  You can find instructions for upgrading here:
  https://docs.getdbt.com/docs/installation
```

Fixed output:
```bash
Core:
  - installed: 1.9.3
  - latest:    1.9.3 - Up to date!

Plugins:
  - singlestore: 1.8.0 - Up to date!
```