### PR TITLE
Fixed invalid imports in impl.py

### DIFF
--- a/dbt/adapters/singlestore/impl.py
+++ b/dbt/adapters/singlestore/impl.py
@@ -45,7 +45,7 @@ class SingleStoreIndexConfig(dbtClassMixin):
             cls.validate(raw_index)
             return cls.from_dict(raw_index)
         except ValidationError as exc:
-            msg = dbt_common.exceptions.validator_error_message(exc)
+            msg = DbtRuntimeError().validator_error_message(exc)
             raise CompilationError(f"Could not parse index config: {msg}")
         except TypeError:
             raise CompilationError(f"Invalid index config:\n  Got: {raw_index}\n"

--- a/dbt/adapters/singlestore/impl.py
+++ b/dbt/adapters/singlestore/impl.py
@@ -45,7 +45,7 @@ class SingleStoreIndexConfig(dbtClassMixin):
             cls.validate(raw_index)
             return cls.from_dict(raw_index)
         except ValidationError as exc:
-            msg = DbtRuntimeError().validator_error_message(exc)
+            msg = DbtRuntimeError(raw_index).validator_error_message(exc)
             raise CompilationError(f"Could not parse index config: {msg}")
         except TypeError:
             raise CompilationError(f"Invalid index config:\n  Got: {raw_index}\n"

--- a/dbt/adapters/singlestore/impl.py
+++ b/dbt/adapters/singlestore/impl.py
@@ -35,7 +35,7 @@ class SingleStoreIndexConfig(dbtClassMixin):
         now = datetime.utcnow().isoformat()
         inputs = self.columns + [relation.render(), str(self.unique), str(self.type), now]
         string = "_".join(inputs)
-        return "index_" + dbt.utils.md5(string)
+        return "index_" + utils.md5(string)
 
     @classmethod
     def parse(cls, raw_index) -> Optional["SingleStoreIndexConfig"]:


### PR DESCRIPTION
## dbt.utils -> dbt_common.utils
The call of `dbt.utils.md5(string)` failed due to the utils existing under `dbt_common.utils` instead of `dbt.utils`.
The import of `dbt_common.utils` was already made, and unused, so the call to the imported function has now been made.

Changed:
```python
import dbt_common.utils #unused import
...
    def render(self, relation):
        ...
        return "index_" + dbt.utils.md5(string)
```

To
```python
import dbt_common.utils
...
    def render(self, relation):
        ...
        return "index_" + utils.md5(string)
```

## validator_error_message call
The call of the function `validator_error_message` has been fixed, with the previous version calling a non-existing function. Now the call runs on the function of the DbtRuntimeError class that the validator inherits from.

Changed:
```python
except ValidationError as exc:
    msg = dbt_common.exceptions.validator_error_message(exc)
    raise CompilationError(f"Could not parse index config: {msg}")
```

To
```python
except ValidationError as exc:
    msg = DbtRuntimeError(raw_index).validator_error_message(exc)
    raise CompilationError(f"Could not parse index config: {msg}")
```