### PR TITLE
Fixed logic and import in get_credentials function

### DIFF
--- a/dbt/adapters/singlestore/connections.py
+++ b/dbt/adapters/singlestore/connections.py
@@ -55,8 +55,8 @@ class SingleStoreConnectionManager(SQLConnectionManager):
 
     @classmethod
     def get_credentials(cls, credentials):
-        if not credentials.database or not credentials.schema:
-            raise dbt_common.exceptions.Exception("database or schema must be specified in the project config")
+        if not (credentials.database or credentials.schema):
+            raise dbt_common.exceptions.DbtConfigError("database or schema must be specified in the project config")
 
         return credentials
 


### PR DESCRIPTION
## get_credentials
The function `get_credentials` of the `SingleStoreConnectionManager` currently will raise an error if either database or schema is undefined instead of the intended functionality where an error is raised only if neither database nor schema are defined.

Changed:
```python
class SingleStoreConnectionManager(SQLConnectionManager):
    TYPE = 'singlestore'

    @classmethod
    def get_credentials(cls, credentials):
        if not credentials.database or not credentials.schema: # triggers is either one is None or ""
            raise dbt_common.exceptions.Exception("database or schema must be specified in the project config")

        return credentials
```

Decision table original:
| result | database  | schema    |
|--------|-----------|-----------|
| Error  | None / "" | "value"   |
| Error  | "value"   | None / "" |
| Error  | None / "" | None / "" |
| OK     | "value"   | "value"   |

To
```python
class SingleStoreConnectionManager(SQLConnectionManager):
    TYPE = 'singlestore'

    @classmethod
    def get_credentials(cls, credentials):
        if not (credentials.database or credentials.schema): 
            raise dbt_common.exceptions.DbtConfigError("database or schema must be specified in the project config")

        return credentials
```

Decision table after change:
| result | database  | schema    |
|--------|-----------|-----------|
| OK     | None / "" | "value"   |
| OK     | "value"   | None / "" |
| Error  | None / "" | None / "" |
| OK     | "value"   | "value"   |


## Exception type change
Changed non-existing `dbt_common.exceptions.Exception` call to `dbt_common.exceptions.DbtConfigError` which seemed like the most suitable Error defined in the dbt_common exceptions.