### PR TITLE
Specify the target database for creation of backup entities

### DIFF
--- a/dbt/include/singlestore/macros/common.sql
+++ b/dbt/include/singlestore/macros/common.sql
@@ -198,7 +198,7 @@
 
 {% macro singlestore__replace_view_definition(from_relation, to_relation) -%}
     {%- set query -%}
-        SELECT CONCAT('CREATE VIEW ', table_name, ' AS ', view_definition, ';')
+        SELECT CONCAT('USING {{ from_relation.database }} CREATE VIEW ', table_name, ' AS ', view_definition, ';')
         FROM information_schema.views
         WHERE table_schema = '{{ from_relation.database }}'
         AND table_name = '{{ from_relation.identifier }}'


### PR DESCRIPTION
## Issue
When creating or replacing a view located in a database other than the database of the target profile, the current behaviour is to materialize that view in the database of the target profile, disregarding the overwritten setting in dbt_project.yml, config block or anywhere in between.

### For example:
> profiles.yml: `target: schema: information_schema`
> dbt_project.yml: `models: my_project: staging: +database: "staging"`
> models/staging/customers.sql:
```SQL
{{
    config(materialized='view', database='staging')
}}

with final as (
    select
        *
    from {{ source('landing', 'raw_customers') }}
)

select * from final
```

**Run result:**
```bash
vscode ➜ /workspace (main) $ dbt run -s customers
18:31:12  Running with dbt=1.9.4
18:31:12  Registered adapter: singlestore=1.8.1
18:31:12  Found 7 seeds, 21 data tests, 1 model, 5 sources, 544 macros
18:31:12  
18:31:12  Concurrency: 8 threads (target='dev')
18:31:12  
18:31:13  1 of 1 START sql view model staging.customers .................................. [RUN]
18:31:13  1 of 1 ERROR creating sql view model staging.customers ......................... [ERROR in 0.32s]
18:31:13  
18:31:13  Finished running 1 view model in 0 hours 0 minutes and 0.56 seconds (0.56s).
18:31:13  
18:31:13  Completed with 1 error, 0 partial successes, and 0 warnings:
18:31:13  
18:31:13    Runtime Error in model customers (models/staging/customers/customers.sql)
  Database Error
    1044: Access denied for user 'root'@'%' to database 'information_schema'
18:31:13  
18:31:13  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```

**Debug run output:**
```bash
18:45:34  Began running node model.dbt_academy.customers
18:45:34  1 of 1 START sql view model staging.customers .................................. [RUN]
18:45:34  Re-using an available connection from the pool (formerly list_staging_information_schema, now model.dbt_academy.customers)
18:45:34  Began compiling node model.dbt_academy.customers
18:45:34  Writing injected SQL for node "model.dbt_academy.customers"
18:45:34  Began executing node model.dbt_academy.customers
18:45:34  Writing runtime sql for node "model.dbt_academy.customers"
18:45:34  Using singlestore connection "model.dbt_academy.customers"
18:45:34  On model.dbt_academy.customers: BEGIN
18:45:34  Opening a new connection, currently in state closed
18:45:34  SQL status: OK. Rows affected: 0 in 0.014 seconds
18:45:34  Using singlestore connection "model.dbt_academy.customers"
18:45:34  On model.dbt_academy.customers: /* run by root */

    create view `staging`.`customers__dbt_tmp` as
        

with final as (
    select
        *
    from `landing`.`raw_customers`
)

select * from final
18:45:34  SQL status: OK. Rows affected: 0 in 0.003 seconds
18:45:34  Using singlestore connection "model.dbt_academy.customers"
18:45:34  On model.dbt_academy.customers: /* run by root */

    show full tables from staging like 'customers__dbt_tmp'
  
18:45:34  SQL status: OK. Rows affected: 1 in 0.000 seconds
18:45:34  Using singlestore connection "model.dbt_academy.customers"
18:45:34  On model.dbt_academy.customers: /* run by root */

    show full tables from staging like 'customers'
  
18:45:34  SQL status: OK. Rows affected: 0 in 0.000 seconds
18:45:34  Using singlestore connection "model.dbt_academy.customers"
18:45:34  On model.dbt_academy.customers: /* run by root */

    SELECT CONCAT('CREATE VIEW ', table_name, ' AS ', view_definition, ';')
        FROM information_schema.views
        WHERE table_schema = 'staging'
        AND table_name = 'customers__dbt_tmp'
  
18:45:34  SQL status: OK. Rows affected: 1 in 0.000 seconds
18:45:34  Using singlestore connection "model.dbt_academy.customers"
18:45:34  On model.dbt_academy.customers: /* run by root */

        
            
    CREATE VIEW customers AS WITH `final` AS (SELECT `raw_customers`.`id` AS `id`, `raw_customers`.`name` AS `name` FROM  `landing`.`raw_customers` as `raw_customers` ) SELECT `final`.`id` AS `id`, `final`.`name` AS `name` FROM  `final` AS `final`;

        
    
18:45:34  SingleStore adapter: Database error: 1044: Access denied for user 'root'@'%' to database 'information_schema'
18:45:34  SingleStore adapter: Error running SQL: macro rename_relation
18:45:34  On model.dbt_academy.customers: ROLLBACK
18:45:34  On model.dbt_academy.customers: Close
18:45:34  Runtime Error in model customers (models/staging/customers/customers.sql)
  Database Error
    1044: Access denied for user 'root'@'%' to database 'information_schema'
18:45:34  Sending event: {'category': 'dbt', 'action': 'run_model', 'label': 'b7c2a16c-4e4d-422c-9a2a-3d94559aa376', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f24aa849610>]}
18:45:34  1 of 1 ERROR creating sql view model staging.customers ......................... [ERROR in 0.07s]
18:45:34  Finished running node model.dbt_academy.customers
18:45:34  Marking all children of 'model.dbt_academy.customers' to be skipped because of status 'error'.  Reason: Runtime Error in model customers (models/staging/customers/customers.sql)
  Database Error
    1044: Access denied for user 'root'@'%' to database 'information_schema'.
18:45:34  Using singlestore connection "master"
18:45:34  On master: BEGIN
18:45:34  Opening a new connection, currently in state closed
18:45:34  SQL status: OK. Rows affected: 0 in 0.015 seconds
18:45:34  On master: COMMIT
18:45:34  Using singlestore connection "master"
18:45:34  On master: COMMIT
18:45:34  SQL status: OK. Rows affected: 0 in 0.000 seconds
18:45:34  On master: Close
18:45:34  Connection 'master' was properly closed.
18:45:34  Connection 'model.dbt_academy.customers' was properly closed.
18:45:34  Connection 'list_landing_information_schema' was properly closed.
18:45:34  
18:45:34  Finished running 1 view model in 0 hours 0 minutes and 0.32 seconds (0.32s).
18:45:34  Command end result
18:45:34  Wrote artifact WritableManifest to /workspace/target/manifest.json
18:45:34  Wrote artifact SemanticManifest to /workspace/target/semantic_manifest.json
18:45:34  Wrote artifact RunExecutionResult to /workspace/target/run_results.json
18:45:34  
18:45:34  Completed with 1 error, 0 partial successes, and 0 warnings:
18:45:34  
18:45:34    Runtime Error in model customers (models/staging/customers/customers.sql)
  Database Error
    1044: Access denied for user 'root'@'%' to database 'information_schema'
```

*We can determine that despite defining the database the default database is still used to create the view.*

## Fix enabling proper database selection:
**Specify the target database with the USING keyword pointing to the from_relation database value:**
> `'CREATE VIEW ', table_name, ' AS ', view_definition, ';'`
gets further specified to
> `'USING {{ from_relation.database }} CREATE VIEW ', table_name, ' AS ', view_definition, ';'`

### **Run result after proposed change:**
```bash
vscode ➜ /workspace (main) $ dbt run -s customers
19:05:58  Running with dbt=1.9.4
19:05:59  Registered adapter: singlestore=1.8.1
19:05:59  Found 7 seeds, 21 data tests, 1 model, 5 sources, 545 macros
19:05:59  
19:05:59  Concurrency: 8 threads (target='dev')
19:05:59  
19:05:59  1 of 1 START sql view model staging.customers .................................. [RUN]
19:05:59  1 of 1 OK created sql view model staging.customers ............................. [OK. Rows affected: 0 in 0.12s]
19:05:59  
19:05:59  Finished running 1 view model in 0 hours 0 minutes and 0.38 seconds (0.38s).
19:05:59  
19:05:59  Completed successfully
19:05:59  
19:05:59  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

**Debug run output:**
```bash
19:07:21  Began running node model.dbt_academy.customers
19:07:21  1 of 1 START sql view model staging.customers .................................. [RUN]
19:07:21  Re-using an available connection from the pool (formerly list_staging_information_schema, now model.dbt_academy.customers)
19:07:21  Began compiling node model.dbt_academy.customers
19:07:21  Writing injected SQL for node "model.dbt_academy.customers"
19:07:21  Began executing node model.dbt_academy.customers
19:07:21  Writing runtime sql for node "model.dbt_academy.customers"
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: BEGIN
19:07:21  Opening a new connection, currently in state closed
19:07:21  SQL status: OK. Rows affected: 0 in 0.014 seconds
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: /* run by root */

    create view `staging`.`customers__dbt_tmp` as
        

with final as (
    select
        *
    from `landing`.`raw_customers`
)

select * from final
19:07:21  SQL status: OK. Rows affected: 0 in 0.007 seconds
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: /* run by root */

    show full tables from staging like 'customers__dbt_tmp'
  
19:07:21  SQL status: OK. Rows affected: 1 in 0.000 seconds
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: /* run by root */

    show full tables from staging like 'customers'
  
19:07:21  SQL status: OK. Rows affected: 0 in 0.000 seconds
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: /* run by root */

    SELECT CONCAT('USING staging CREATE VIEW ', table_name, ' AS ', view_definition, ';')
        FROM information_schema.views
        WHERE table_schema = 'staging'
        AND table_name = 'customers__dbt_tmp'
  
19:07:21  SQL status: OK. Rows affected: 1 in 0.000 seconds
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: /* run by root */

        
            
    USING staging CREATE VIEW customers AS WITH `final` AS (SELECT `raw_customers`.`id` AS `id`, `raw_customers`.`name` AS `name` FROM  `landing`.`raw_customers` as `raw_customers` ) SELECT `final`.`id` AS `id`, `final`.`name` AS `name` FROM  `final` AS `final`;

        
    
19:07:21  SQL status: OK. Rows affected: 0 in 0.010 seconds
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: /* run by root */

        drop view `staging`.`customers__dbt_tmp`
        
19:07:21  SQL status: OK. Rows affected: 0 in 0.006 seconds
19:07:21  On model.dbt_academy.customers: COMMIT
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: COMMIT
19:07:21  SQL status: OK. Rows affected: 0 in 0.000 seconds
19:07:21  Using singlestore connection "model.dbt_academy.customers"
19:07:21  On model.dbt_academy.customers: /* run by root */
drop view if exists `staging`.`customers__dbt_backup`
19:07:21  SQL status: OK. Rows affected: 0 in 0.000 seconds
19:07:21  On model.dbt_academy.customers: Close
19:07:21  Sending event: {'category': 'dbt', 'action': 'run_model', 'label': 'ac01cf42-8658-49be-ac2a-ff75fea44fd3', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6ac6c90d0>]}
19:07:21  1 of 1 OK created sql view model staging.customers ............................. [OK. Rows affected: 0 in 0.11s]
19:07:21  Finished running node model.dbt_academy.customers
19:07:21  Using singlestore connection "master"
19:07:21  On master: BEGIN
19:07:21  Opening a new connection, currently in state closed
19:07:21  SQL status: OK. Rows affected: 0 in 0.014 seconds
19:07:21  On master: COMMIT
19:07:21  Using singlestore connection "master"
19:07:21  On master: COMMIT
19:07:21  SQL status: OK. Rows affected: 0 in 0.000 seconds
19:07:21  On master: Close
19:07:21  Connection 'master' was properly closed.
19:07:21  Connection 'list_landing_information_schema' was properly closed.
19:07:21  Connection 'model.dbt_academy.customers' was properly closed.
19:07:21  
19:07:21  Finished running 1 view model in 0 hours 0 minutes and 0.38 seconds (0.38s).
19:07:21  Command end result
19:07:21  Wrote artifact WritableManifest to /workspace/target/manifest.json
19:07:21  Wrote artifact SemanticManifest to /workspace/target/semantic_manifest.json
19:07:21  Wrote artifact RunExecutionResult to /workspace/target/run_results.json
19:07:21  
19:07:21  Completed successfully
19:07:21  
19:07:21  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```