### PR TITLE
Resolve issue with backup views

### DIFF
--- a/dbt/include/singlestore/macros/catalog.sql
+++ b/dbt/include/singlestore/macros/catalog.sql
@@ -6,12 +6,12 @@
         columns.table_schema,
         columns.table_name,
         tables.table_type,
-        nullif(columns.table_comment, ''),
+        nullif(columns.table_comment, '') as table_comment,
         tables.table_owner,
         columns.column_name,
         columns.column_index,
         columns.column_type,
-        nullif(columns.column_comment, '')
+        nullif(columns.column_comment, '') as column_comment
     from
         ({{singlestore__get_catalog_tables_sql(information_schema)}}) as tables
     join
@@ -35,12 +35,12 @@
         columns.table_schema,
         columns.table_name,
         tables.table_type,
-        nullif(columns.table_comment, ''),
+        nullif(columns.table_comment, '') as table_comment,
         tables.table_owner,
         columns.column_name,
         columns.column_index,
         columns.column_type,
-        nullif(columns.column_comment, '')
+        nullif(columns.column_comment, '') as column_comment
     from
         ({{singlestore__get_catalog_tables_sql(information_schema)}}
         {{ singlestore__get_catalog_relations_where_clause_sql(relations) }}) as tables

--- a/dbt/include/singlestore/macros/materializations/view.sql
+++ b/dbt/include/singlestore/macros/materializations/view.sql
@@ -1,0 +1,70 @@
+{%- materialization view, adapter='singlestore' -%}
+
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='view') -%}
+  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
+
+  -- the intermediate_relation should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  /*
+     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from
+     a previous run, and we're going to try to drop it immediately. At the end of this
+     materialization, we're going to rename the "existing_relation" to this identifier,
+     and then we're going to drop it. In order to make sure we run the correct one of:
+       - drop view ...
+       - drop table ...
+
+     We need to set the type of this relation to be the type of the existing_relation, if it exists,
+     or else "view" as a sane default if it does not. Note that if the existing_relation does not
+     exist, then there is nothing to move out of the way and subsequentally drop. In that case,
+     this relation will be effectively unused.
+  */
+  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+  -- as above, the backup_relation should not already exist
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  -- grab current tables grants config for comparision later on
+  {% set grant_config = config.get('grants') %}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- drop the temp relations if they exist already in the database
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ get_create_view_as_sql(intermediate_relation, sql) }}
+  {%- endcall %}
+
+  -- cleanup
+  -- move the existing view out of the way
+  {% if existing_relation is not none %}
+     {% set existing_relation = load_cached_relation(existing_relation) %}
+     {% if existing_relation is not none %}
+         {{ drop_relation_if_exists(existing_relation) }}
+     {% endif %}
+  {% endif %}
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {{ adapter.commit() }}
+
+  {{ drop_relation_if_exists(backup_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization -%}


### PR DESCRIPTION
In the default “view” materialization, the code used to preserve the existing view by renaming it to a **__dbt_backup** object before swapping in the new **__dbt_tmp** view.

This backup-then-swap pattern caused failures whenever the underlying table schema changed (for example, if a column was renamed). Because renaming the old view effectively re-ran its stale **CREATE VIEW … AS <old-column-select>**, SingleStore would raise “Unknown column” errors when the old definition still referenced a column that no longer existed.

Instead of renaming the existing view to **__dbt_backup** and then dropping it later, we now simply drop the existing view immediately after creating the intermediate view.

The PR also includes a minor update to the **table_comment** and **column_comment** retrieval logic to eliminate runtime warnings.