### PR TITLE
Fixed snapshot insert statement using incorrect target database

### DIFF
--- a/dbt/include/singlestore/macros/materializations/snapshot/helpers.sql
+++ b/dbt/include/singlestore/macros/materializations/snapshot/helpers.sql
@@ -89,7 +89,7 @@
 
 
 {% macro singlestore__insert_select(relation, select_query) %}
-    insert into {{ relation.include(database=False) }}
+    insert into {{ relation.include(database=True) }}
     {{ select_query }}
 {% endmacro %}
 


### PR DESCRIPTION
## Issue synopsis
Snapshots don't use the target database to insert the new data, creating a mismatch between the location of the temporary table and the target table for the data batch.

## Solution
Change line 92 from `insert into {{ relation.include(database=False) }}` to `insert into {{ relation.include(database=True) }}`

### Breakdown
#### On first run
```SQL
create table `datavault`.`customers_snapshot`(SHARD KEY ()) as
{{ statement }};
```

#### On consecutive runs
```SQL
create rowstore temporary table `datavault`.`customers_snapshot__dbt_tmp`(SHARD KEY ()) as
{{ statement }};
```
```SQL
insert into `customers_snapshot__dbt_tmp`
with snapshot_query as (
{{ statement }};
```
Note the lacking database for the insert into. This means that the default database of the dbt connection will be used, which most of the time won't be the location of the snapshot table.
After changing the macro `insert_select` the following happens instead:
```SQL
create rowstore temporary table `datavault`.`customers_snapshot__dbt_tmp`(SHARD KEY ()) as
{{ statement }};
```
```SQL
insert into `datavault`.`customers_snapshot__dbt_tmp`
with snapshot_query as (
{{ statement }};
```
Where the location of the snapshot table is correctly set as the target table