### PR TITLE
Handling invalid relation types after type retrieval instead of raising runtimeerrors

### DIFF
--- a/dbt/adapters/singlestore/impl.py
+++ b/dbt/adapters/singlestore/impl.py
@@ -11,6 +11,7 @@ from dbt.adapters.singlestore.relation import SingleStoreRelation
 from dbt.adapters.base.impl import ConstraintSupport
 from dbt.adapters.base.meta import available
 from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
+from dbt.adapters.contracts.relation import RelationType
 from dbt.adapters.sql import SQLAdapter
 from dbt_common.contracts.constraints import ColumnLevelConstraint, ConstraintType, ModelLevelConstraint
 from dbt_common.dataclass_schema import dbtClassMixin, ValidationError
@@ -142,6 +143,9 @@ class SingleStoreAdapter(SQLAdapter):
                     f'got {len(row)} values, expected 4'
                 )
             database, name, schema, relation_type = row
+            if relation_type not in RelationType:
+                logger.debug(f"Invalid value from singlestore__list_relations_without_caching({kwargs}): {relation_type}")
+                continue
             relation = self.Relation.create(
                 database=database,
                 schema=schema,


### PR DESCRIPTION
## Issue synopsis
A dbt Relation object is attempted to be created regardless if the type of relation is a known valid type (exists in [dbt RelationType enum](https://github.com/dbt-labs/dbt-adapters/blob/52fda88ae6c32a2edfaecda46ad29b62c03bb051/dbt-adapters/src/dbt/adapters/contracts/relation.py#L16)).

### Breakdown
In the function `list_relations_without_caching` of `impl.py`, the result of the macro `singlestore__list_relations_without_caching` can include a type of, for example, `'SYSTEM VIEW'`. This value is then passed to create a `Relation`, which only accepts values of the `RelationType` enum. To avoid the mismatch, skip creating this relation and continue with acceptable values.

## Solution
Continue (skip) creation of list of Relations when encountering an invalid relation instead of Calling the contructor with an invalid field, causing a RuntimeError.

#### Alternative proposal
Override the RelationType class to include all possible types known to SingleStore, making it possible to create exotic Relations as well