### PR TITLE
Added option for reference table creation using storage_type keyword

### DIFF
--- a/dbt/include/singlestore/macros/common.sql
+++ b/dbt/include/singlestore/macros/common.sql
@@ -37,6 +37,7 @@
     {%- set sort_key = config.get('sort_key', []) -%} {# SORT KEY (sort_key) #}
     {%- set shard_key = config.get('shard_key', []) -%} {# SHARD KEY (shard_key) #}
     {%- set unique_table_key = config.get('unique_table_key', []) -%} {# UNIQUE KEY (unique_table_key) #}
+    {%- set storage_type = config.get('storage_type', '') -%} {# REFERENCE | ROWSTORE #}
     {%- set charset = config.get('charset', none) -%} {# CHARACTER SET charset #}
     {%- set collation = config.get('collation', none) -%} {# COLLATE collation #}
     {%- set contract_config = config.get('contract') -%}
@@ -90,10 +91,14 @@
     {% if create_definition_list | length -%}
         {% set create_definition_str = create_definition_list|join(", ") -%}
     {% elif not contract_defined_primary and not contract_defined_unique -%}
-        {% set create_definition_str = 'SHARD KEY ()' -%}
+        {% if storage_type | lower == 'reference' -%}
+            {% set create_definition_str = '' -%}
+        {% else -%}
+            {% set create_definition_str = 'SHARD KEY ()' -%}
+        {% endif -%}
     {% endif -%}
 
-    {% if not contract_config.enforced -%}
+    {% if not contract_config.enforced and create_definition_str | length -%}
         {% set create_definition_str = '(' + create_definition_str + ')' -%}
     {% endif -%}
 
@@ -113,10 +118,6 @@
         {% else -%}
             {% set storage_type = 'rowstore temporary' -%}
         {% endif -%}
-    {% elif config.get('storage_type') == 'rowstore' -%}
-        {% set storage_type = 'rowstore' -%}
-    {% else -%}
-        {% set storage_type = '' -%}
     {% endif -%}
 
     create {{ storage_type }} table


### PR DESCRIPTION
## Issue synopsis
There is a need to create reference tables in dbt-singlestore

## Solution
Accept a new `storage_type` configuration option for tables which will accept 'reference'/'REFERENCE' as it's value, altering the `CREATE TABLE` statement to `CREATE REFERENCE TABLE`. This should be done without impacting existing functionality.

### Breakdown
#### testmodel.sql
```SQL
{{
    config(
        database='staging',
        materialized='table',
        storage_type='reference'
    )
}}
select 1
```

#### Before change
Will run as:
```SQL
create  table `staging`.`testmodel` (SHARD KEY ()) as ...
```

#### After considering the reference option in `singlestore__create_table_as`
```SQL
create reference table `staging`.`testmodel__dbt_tmp` as ...
```

#### Without impacting other types of table
```SQL
{{
    config(
        database='staging',
        materialized='table',
        storage_type='rowstore'
    )
}}
select 1
```
Will still normally run as 
```SQL
create rowstore table `staging`.`testmodel` (SHARD KEY ()) as
{{ statement }};
```
And setting a shard key for the reference table will expectedly result in an error:
```SQL
{{
    config(
        database='staging',
        materialized='table',
        storage_type='reference',
        shard_key=['1'],
    )
}}
select 1
```
Will throw the error
```SQL
1706: Feature 'Sharded reference tables' is not supported by SingleStore.
compiled code at target/run/dbt_academy/models/testmodel.sql
```