### PR TITLE
Fix multi-CTE rendering under --empty and unit-test casts on string columns

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Unreleased
+- Fix `singlestore__strip_db_limit_aliases` corrupting multi-CTE models under `dbt run --empty`: bound the trailing ` as ` lookup to the same physical SQL line so the `_dbt_limit_subq_<n>` cleanup can no longer splice across CTE boundaries
+- Fix `singlestore__safe_cast` rejecting Postgres-flavored type names that arrive from dbt-core's unit-test fixture rendering (`character varying(N)` / bare `character varying`); translate them to SingleStore-native targets (`varchar(N)` / `longtext`) so unit tests with string columns no longer fail to compile or silently truncate (regression of dbt-labs/dbt-core#11974)
+- Subscribe to `BaseUnitTestingVarcharFixtureNoTruncation` and add a multi-CTE `--empty` regression test
+
 ### 1.9.1
 - Added extensive new adapter tests for hooks, catalogs, aliases, column types, query comments, simple seeds, and other core dbt behaviors
 

--- a/dbt/include/singlestore/macros/common.sql
+++ b/dbt/include/singlestore/macros/common.sql
@@ -290,12 +290,14 @@
     {# Recursively remove occurrences of:
         "... ) _dbt_limit_subq_<name> as <final_alias>"
         which produce invalid "double alias" SQL in SingleStore.
+
+        The double-alias is always emitted on a single physical SQL line by
+        dbt-core, so the search for the trailing ` as ` MUST be bounded to that
+        same line. A previous implementation searched forward globally, which
+        in multi-CTE models matched the next CTE's `as (` and corrupted the
+        rendered SQL by splicing across CTE boundaries.
     #}
     {%- set token = '_dbt_limit_subq_' -%}
-
-    {%- if token not in sql -%}
-    {{ return(sql) }}
-    {%- endif -%}
 
     {%- set pos = sql.find(token) -%}
     {%- if pos == -1 -%}
@@ -308,10 +310,21 @@
     {{ return(sql) }}
     {%- endif -%}
 
-    {# find " as " following the intermediate alias #}
-    {%- set as_pos = sql.find(' as ', pos) -%}
+    {# bound the ` as ` lookup to the current physical SQL line #}
+    {%- set line_end = sql.find('\n', pos) -%}
+    {%- if line_end == -1 -%}
+        {%- set line_end = sql|length -%}
+    {%- endif -%}
+
+    {%- set as_pos = sql.find(' as ', pos, line_end) -%}
     {%- if as_pos == -1 -%}
-    {{ return(sql) }}
+        {# No double-alias on this line: leave the intermediate alias intact
+           (it is valid SingleStore SQL on its own) and recurse on the
+           remainder past the line break, so each recursion shrinks the input
+           by at least one line. #}
+        {%- set head = sql[:line_end] -%}
+        {%- set rest = singlestore__strip_db_limit_aliases(sql[line_end:]) -%}
+        {{ return(head ~ rest) }}
     {%- endif -%}
 
     {# keep everything after " as " (including potential trailing SQL) #}

--- a/dbt/include/singlestore/macros/utils/safe_cast.sql
+++ b/dbt/include/singlestore/macros/utils/safe_cast.sql
@@ -34,12 +34,19 @@
     -#}
     {%- set raw = (type or '') | string | trim -%}
     {%- set lowered = raw | lower -%}
+    {#- Replacements operate on `lowered`, not `raw`: the branch selection is
+        case-insensitive (via `startswith`/`==` on `lowered`), so any mixed-case
+        input (e.g. `Character Varying(10)`) reaches the right branch. Replacing
+        on `raw` with hard-coded all-lower / all-upper literals would miss those
+        mixed-case forms and let the Postgres-flavored type leak through to the
+        `!:>` cast unchanged. SingleStore type names are case-insensitive, so
+        normalising to lower-case in the output is harmless. -#}
     {%- if lowered == 'character varying' or lowered == 'character' -%}
         longtext
     {%- elif lowered.startswith('character varying(') -%}
-        {{- raw | replace('character varying', 'varchar') | replace('CHARACTER VARYING', 'varchar') -}}
+        {{- lowered | replace('character varying', 'varchar') -}}
     {%- elif lowered.startswith('character(') -%}
-        {{- raw | replace('character', 'char') | replace('CHARACTER', 'char') -}}
+        {{- lowered | replace('character', 'char') -}}
     {%- else -%}
         {{- raw -}}
     {%- endif -%}

--- a/dbt/include/singlestore/macros/utils/safe_cast.sql
+++ b/dbt/include/singlestore/macros/utils/safe_cast.sql
@@ -1,5 +1,46 @@
 {% macro singlestore__safe_cast(field, type) %}
 
-    ({{field}} !:> {{type}})
+    ({{ field }} !:> {{ singlestore__translate_safe_cast_type(type) }})
 
 {% endmacro %}
+
+
+{% macro singlestore__translate_safe_cast_type(type) -%}
+    {#-
+        Translate Postgres-flavored type names that arrive from dbt-core
+        (notably from `Column.data_type` via `string_type`/`numeric_type`)
+        into SingleStore-native equivalents that the `!:>` cast operator can
+        parse.
+
+        Background:
+          dbt-core's unit-test fixture rendering passes
+          `safe_cast(value, column.data_type)` for every value, and the
+          base `Column.data_type` normalises any varchar/text column to the
+          Postgres-style "character varying(N)". dbt-core 1.11+ additionally
+          strips the length when the value is a string (dbt-labs/dbt-core
+          GH-11974, to prevent silent truncation), producing a bare
+          "character varying" form. SingleStore rejects both forms in `!:>`,
+          and a bare `!:> char` silently truncates to a single character —
+          so the unbounded cast is mapped to `longtext` (TEXT family) which
+          preserves the full value.
+
+        Translation table:
+          character varying(N) -> varchar(N)
+          character varying    -> longtext        (unbounded; no truncation)
+          character(N)         -> char(N)
+          character            -> longtext        (unbounded; no truncation)
+          everything else      -> pass-through    (numeric / json / temporal
+                                                   types are already valid)
+    -#}
+    {%- set raw = (type or '') | string | trim -%}
+    {%- set lowered = raw | lower -%}
+    {%- if lowered == 'character varying' or lowered == 'character' -%}
+        longtext
+    {%- elif lowered.startswith('character varying(') -%}
+        {{- raw | replace('character varying', 'varchar') | replace('CHARACTER VARYING', 'varchar') -}}
+    {%- elif lowered.startswith('character(') -%}
+        {{- raw | replace('character', 'char') | replace('CHARACTER', 'char') -}}
+    {%- else -%}
+        {{- raw -}}
+    {%- endif -%}
+{%- endmacro %}

--- a/tests/functional/adapter/test_empty.py
+++ b/tests/functional/adapter/test_empty.py
@@ -1,4 +1,7 @@
+import pytest
+
 from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
+from dbt.tests.util import run_dbt
 
 
 class TestSingleStoreEmpty(BaseTestEmpty):
@@ -7,3 +10,46 @@ class TestSingleStoreEmpty(BaseTestEmpty):
 
 class TestSingleStoreEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
     pass
+
+
+# Regression test for the multi-CTE --empty rendering bug.
+# `dbt run --empty` rewrites every {{ ref(...) }} as a `_dbt_limit_subq_<n>`
+# limited subquery. The singlestore__strip_db_limit_aliases macro must clean
+# those tokens up *only on their own physical SQL line*; an earlier
+# implementation searched forward globally for the trailing ` as ` and, in
+# multi-CTE models, matched the next CTE's `as (` instead, splicing across
+# CTE boundaries and producing invalid SQL such as `(...) as (` with the
+# next CTE's alias swallowed.
+_upstream_a_sql = "select 1 as id, 'a' as name"
+_upstream_b_sql = "select 1 as id, 10 as score"
+
+_multi_cte_model_sql = """
+with a as (
+    select id, name from {{ ref('upstream_a') }}
+),
+
+b as (
+    select id, score from {{ ref('upstream_b') }}
+)
+
+select a.id, a.name, b.score
+from a
+join b on a.id = b.id
+"""
+
+
+class TestSingleStoreEmptyMultiCTE:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "upstream_a.sql": _upstream_a_sql,
+            "upstream_b.sql": _upstream_b_sql,
+            "multi_cte_model.sql": _multi_cte_model_sql,
+        }
+
+    def test_run_empty_on_multi_cte_model(self, project):
+        # baseline run should always succeed
+        run_dbt(["run"])
+        # --empty must compile + execute the multi-CTE view without splicing
+        # CTE boundaries when stripping the _dbt_limit_subq_ aliases
+        run_dbt(["run", "--empty"])

--- a/tests/functional/adapter/test_unit_testing.py
+++ b/tests/functional/adapter/test_unit_testing.py
@@ -1,6 +1,12 @@
 import pytest
 
-from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
+from dbt.tests.adapter.unit_testing.test_types import (
+    BaseUnitTestingTypes,
+    BaseUnitTestingVarcharFixtureNoTruncation,
+    _length_model_sql,
+    _length_test_yml,
+    my_upstream_model_sql,
+)
 from dbt.tests.adapter.unit_testing.test_case_insensitivity import BaseUnitTestCaseInsensivity
 from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
 
@@ -29,3 +35,30 @@ class TestSingleStoreUnitTestCaseInsensitivity(BaseUnitTestCaseInsensivity):
 
 class TestSingleStoreUnitTestInvalidInput(BaseUnitTestInvalidInput):
     pass
+
+
+# Regression test for unit-test fixture casts on string columns.
+# When the upstream model declares a narrow varchar (here: varchar(5)) and the
+# unit-test fixture provides a longer string, dbt-core 1.11+ strips the length
+# from the cast type to avoid silent truncation (dbt-labs/dbt-core GH-11974)
+# and calls singlestore__safe_cast(value, "character varying"). Without the
+# Postgres-style -> SingleStore-native translation the rendered SQL is either
+# rejected (`!:> varchar` requires a length) or silently truncates to one
+# character (`!:> char`). The fix maps the unbounded form to `longtext`.
+#
+# The base test's upstream model uses ANSI `cast(x as varchar(5))`, which
+# SingleStore's CAST does not accept. We override the model to use the
+# SingleStore-native `:>` cast operator while preserving the test's intent
+# (a narrow varchar column whose fixture must not be truncated).
+class TestSingleStoreUnitTestingVarcharFixtureNoTruncation(
+    BaseUnitTestingVarcharFixtureNoTruncation
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": _length_model_sql,
+            "my_upstream_model.sql": my_upstream_model_sql.format(
+                sql_value="('short' :> varchar(5))"
+            ),
+            "schema.yml": _length_test_yml,
+        }

--- a/tests/functional/adapter/test_unit_testing.py
+++ b/tests/functional/adapter/test_unit_testing.py
@@ -62,3 +62,53 @@ class TestSingleStoreUnitTestingVarcharFixtureNoTruncation(
             ),
             "schema.yml": _length_test_yml,
         }
+
+
+# Direct unit test for the singlestore__translate_safe_cast_type helper.
+# In practice dbt-core only ever passes a fully lower-case Postgres-flavored
+# type into safe_cast (since Column.string_type/numeric_type produce lower-case
+# strings), so the BaseUnitTestingVarcharFixtureNoTruncation regression above
+# only exercises the lower-case path. This test pins down the *case-insensitive*
+# contract of the translator so a future "simplification" of the macro can't
+# silently let mixed-case Postgres types leak through to the `!:>` cast (which
+# would fail at runtime with a SingleStore parse error).
+class TestSingleStoreTranslateSafeCastType:
+    @pytest.fixture(scope="class")
+    def models(self):
+        # A trivial model is required for the project fixture to bootstrap;
+        # we don't materialise it.
+        return {"placeholder.sql": "select 1 as one"}
+
+    @pytest.mark.parametrize(
+        "input_type,expected",
+        [
+            # Lower-case Postgres-flavored inputs (what dbt-core actually emits).
+            ("character varying(30)", "varchar(30)"),
+            ("character varying", "longtext"),
+            ("character(10)", "char(10)"),
+            ("character", "longtext"),
+            # Mixed / upper case inputs: branch selection is case-insensitive,
+            # so the translation MUST also be case-insensitive end-to-end.
+            ("Character Varying(30)", "varchar(30)"),
+            ("CHARACTER VARYING(30)", "varchar(30)"),
+            ("Character(10)", "char(10)"),
+            ("CHARACTER(10)", "char(10)"),
+            # SingleStore-native and unrelated types must pass through untouched.
+            ("varchar(30)", "varchar(30)"),
+            ("bigint(20)", "bigint(20)"),
+            ("JSON", "JSON"),
+            ("timestamp", "timestamp"),
+        ],
+    )
+    def test_translates_postgres_string_types_case_insensitively(
+        self, project, input_type, expected
+    ):
+        with project.adapter.connection_named("_test"):
+            actual = project.adapter.execute_macro(
+                "singlestore__translate_safe_cast_type",
+                kwargs={"type": input_type},
+            )
+        assert actual.strip() == expected, (
+            f"singlestore__translate_safe_cast_type({input_type!r}) "
+            f"returned {actual.strip()!r}; expected {expected!r}"
+        )


### PR DESCRIPTION
## Problem

Two bugs in the current adapter prevent dbt-core 1.11+ from compiling common project shapes against SingleStore. Both are reproducible on `master @ 0eadd34` against `dbt-core` HEAD (1.12.0a1) + `dbt-adapters` 1.23.0, and one of them already breaks an existing test in this repo (`TestSingleStoreUnitTestingTypes`) — see "Reproductions" below.

### Bug 1 — `singlestore__strip_db_limit_aliases` corrupts multi-CTE models under `dbt run --empty`

`dbt run --empty` rewrites every `{{ ref(...) }}` as a `_dbt_limit_subq_<n>` limited subquery. The current cleanup macro searches forward globally for the next `' as '`. In multi-CTE models that match is the *next* CTE's `as (`, so the rewrite splices across CTE boundaries and produces invalid SQL such as `(...) as (` with the next CTE's alias swallowed.

Minimal repro (fails on `master`, passes on this branch):

\`\`\`sql
-- multi_cte_model.sql
with a as (select id, name from {{ ref('upstream_a') }}),
     b as (select id, score from {{ ref('upstream_b') }})
select a.id, a.name, b.score from a join b on a.id = b.id
\`\`\`

\`\`\`
$ dbt run --empty
Database Error in model multi_cte_model
1064: You have an error in your SQL syntax; check the manual that corresponds to
your MySQL server version for the right syntax to use near
'(\n      select id, score from (select * from `dbt_test`.`upstream_b` where false l'
\`\`\`

### Bug 2 — `singlestore__safe_cast` rejects Postgres-flavored type names from unit-test fixture casts

dbt-core's unit-test fixture renderer calls `safe_cast(value, column.data_type)` for every fixture value. The base `Column.data_type` normalises any varchar/text column to the Postgres-style `"character varying(N)"`. dbt-core 1.11+ additionally strips the length when the value is a string (dbt-labs/dbt-core#11974, to prevent silent truncation), producing a bare `"character varying"` form. SingleStore's `!:>` rejects both forms outright, and a bare `!:> char` silently truncates to a single character.

Repro: this repo's existing `TestSingleStoreUnitTestingTypes` against `dbt-core` HEAD already fails on `master` with:

\`\`\`
Database Error
1064: You have an error in your SQL syntax; check the manual that corresponds to
your MySQL server version for the right syntax to use near ' character varying)
 as `tested_column`
) select tested_column from __dbt__'
\`\`\`

## Solution

Two surgical macro changes plus matching tests.

### `singlestore__strip_db_limit_aliases` (`dbt/include/singlestore/macros/common.sql`)

The double-alias is always emitted by dbt-core on a single physical SQL line, so the trailing `' as '` lookup MUST be bounded to that same line. Two changes:

1. Bound `sql.find(' as ', pos, line_end)` to the current physical SQL line.
2. When no double-alias is present on the current line, leave the intermediate alias intact (it is valid SingleStore SQL on its own) and recurse on the remainder past the line break, so each recursion shrinks the input by at least one line.

### `singlestore__safe_cast` (`dbt/include/singlestore/macros/utils/safe_cast.sql`)

A new private helper `singlestore__translate_safe_cast_type` translates Postgres-flavored type names to SingleStore-native cast targets *only* in the `safe_cast` path (so contract / introspection paths that legitimately expect the Postgres-canonical names are untouched):

| Input | Output |
|---|---|
| `character varying(N)` | `varchar(N)` |
| `character varying`     | `longtext` (unbounded; no truncation) |
| `character(N)`          | `char(N)` |
| `character`             | `longtext` (unbounded; no truncation) |
| anything else           | pass-through |

`longtext` is used for the unbounded form because a bare `!:> varchar` is a SingleStore parse error and a bare `!:> char` silently truncates to a single character (verified locally: `('EMP001' !:> char)` → `'E'`).

## Tests

- `tests/functional/adapter/test_empty.py` — new `TestSingleStoreEmptyMultiCTE`: a two-CTE model that runs `dbt run` followed by `dbt run --empty`. Fails before the fix, passes after.
- `tests/functional/adapter/test_unit_testing.py` — subscribed to the upstream `BaseUnitTestingVarcharFixtureNoTruncation` (the regression test class for dbt-labs/dbt-core#11974), with a thin `models` override to replace the upstream fixture's ANSI `cast(x as varchar(5))` with SingleStore's native `('short' :> varchar(5))` (SingleStore's `CAST` does not accept `varchar(N)` as a target).

## Backward compatibility

Both macros are pure replacements of existing public macros; no signatures change. The `safe_cast` translator only narrows behavior for inputs the previous macro could not handle anyway. No adapter Python code is touched.

## Local validation

Against `dbt-core` HEAD + `dbt-adapters` 1.23.0 + SingleStore 5.7.32:

- Both bugs reproduced on `master` before the fix.
- `tests/functional/adapter/test_empty.py` + `tests/functional/adapter/test_unit_testing.py` — 7/7 green after the fix.
- Wider smoke (`test_basic`, `test_dbt_show`, `test_ephemeral`, `test_relations`, `test_dbt_debug`, `test_aliases`, `test_query_comment`, several `test_utils` classes) — 48/51. The 3 remaining failures (`TestIncrementalSingleStore`, `TestSnapshotCheckColsSingleStore`, `TestSnapshotTimestampSingleStore`) and the 3 `test_caching.py` failures are all pre-existing on `master` (verified by re-running them with the diff stashed) and require the per-suite `drop_and_create_new_db` isolation that `.github/workflows/run-tests.sh` uses in CI.

## Changelog

`Unreleased` section added in `CHANGELOG.MD` documenting both fixes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SQL-rendering macros (`singlestore__strip_db_limit_aliases` and `singlestore__safe_cast`) used broadly during compilation/execution; while changes are targeted and covered by new regressions tests, mistakes could impact SQL generation across many models.
> 
> **Overview**
> Fixes two SingleStore adapter macro regressions affecting dbt-core 1.11+.
> 
> `singlestore__strip_db_limit_aliases` now bounds its trailing ` as ` search to the same physical SQL line and recurses by line when no double-alias is present, preventing `dbt run --empty` from corrupting multi-CTE SQL.
> 
> `singlestore__safe_cast` now routes cast targets through a new `singlestore__translate_safe_cast_type` helper that converts Postgres-flavored string types (e.g. `character varying(N)`/`character varying`) to SingleStore-valid targets (`varchar(N)`/`longtext`) to avoid compilation failures or truncation in unit-test fixtures. Adds/extends functional tests to lock in both behaviors and documents the fixes in `CHANGELOG.MD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e36d7e26b961ee87902acbf09fa0d77d76e27a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->