### PR TITLE
chore: update dev_requirements

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -66,11 +66,15 @@ TESTS=(
 
   "pytest ./tests/functional/adapter/test_simple_copy.py"
 
+  "pytest ./tests/functional/adapter/test_basic.py"
+  "pytest ./tests/functional/adapter/test_concurrency.py"
+
   # Run everything else except what’s already run separately
   "pytest -k 'not TestSingleStoreMicrobatch and not ConstraintsRollback and not TestSnapshot
               and not test_caching and not test_relation_type and not test_docs and not test_ephemeral
               and not test_list_relations_without_caching and not test_snapshots and not test_hooks
-              and not test_simple_seed and not test_simple_copy'"
+              and not test_simple_seed and not test_simple_copy
+              and not test_basic and not test_concurrency'"
 )
 
 result_code=0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,10 +1,10 @@
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@1.latest#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-common.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-adapters
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 
-pytest==7.3.1
+pytest>=9.0.3
 pytest-dotenv==0.5.2
 pytz==2023.3
-singlestoredb==1.15.8
+singlestoredb==1.17.0
 

--- a/tests/utils/sql_patch_helpers.py
+++ b/tests/utils/sql_patch_helpers.py
@@ -28,18 +28,18 @@ class SqlGlobalOverrideMixin:
     SQL_GLOBAL_OVERRIDES = {}
 
     @pytest.fixture(autouse=True, scope="class")
-    def patch_sql_globals(self, request):
-        if self.BASE_TEST_CLASS is None:
+    @classmethod
+    def patch_sql_globals(cls, request):
+        if cls.BASE_TEST_CLASS is None:
             raise RuntimeError(
                 "SqlGlobalOverrideMixin requires `BASE_TEST_CLASS` to be defined."
             )
 
-        base_module = importlib.import_module(self.BASE_TEST_CLASS.__module__)
+        base_module = importlib.import_module(cls.BASE_TEST_CLASS.__module__)
         mp = pytest.MonkeyPatch()
 
-        try:
-            for global_name, sql_value in self.SQL_GLOBAL_OVERRIDES.items():
-                mp.setattr(base_module, global_name, sql_value, raising=False)
-        finally:
-            # Ensure patches are always reverted after the class completes
-            request.addfinalizer(mp.undo)
+        # Register cleanup before applying patches, so partial patching is also reverted.
+        request.addfinalizer(mp.undo)
+
+        for global_name, sql_value in cls.SQL_GLOBAL_OVERRIDES.items():
+            mp.setattr(base_module, global_name, sql_value, raising=False)


### PR DESCRIPTION
- Updated the `dbt-core` Git dependency to use the `1.latest` branch instead of `main`.
dbt Core v1 development has moved to `1.latest`. The `main` branch now contains dbt Core v2/Fusion work and no longer matches the Python dbt Core v1 project layout expected by the current test setup.
- Updated `pytest` to a newer version.
- Updated `singlestoredb` to a newer version.